### PR TITLE
Add popup home page with icon and buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+*.png

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,30 +1,29 @@
-<script setup>
-import HelloWorld from './components/HelloWorld.vue'
-</script>
-
 <template>
-  <div>
-    <a href="https://vite.dev" target="_blank">
-      <img src="/vite.svg" class="logo" alt="Vite logo" />
-    </a>
-    <a href="https://vuejs.org/" target="_blank">
-      <img src="./assets/vue.svg" class="logo vue" alt="Vue logo" />
-    </a>
+  <div class="home">
+    <img src="/assets/img/icon.png" alt="Asian Mom Pomodoro icon" class="home__icon" />
+    <div class="home__buttons">
+      <button>beallitasok</button>
+      <button>strart pomodoro</button>
+    </div>
   </div>
-  <HelloWorld msg="Vite + Vue" />
 </template>
 
 <style scoped>
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
+.home {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
 }
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
+.home__icon {
+  width: 128px;
+  height: 128px;
+  margin-bottom: 1rem;
 }
-.logo.vue:hover {
-  filter: drop-shadow(0 0 2em #42b883aa);
+.home__buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 </style>


### PR DESCRIPTION
## Summary
- create a basic popup home page for the extension with centered icon and two buttons
- ignore PNG files via `.gitignore`
- reference existing icon asset without committing binaries

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b45c78d9cc83239ce07d67f04decca