### PR TITLE
Add settings component with language and message options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "asianmomapp",
       "version": "0.0.0",
       "dependencies": {
-        "vue": "^3.5.18"
+        "vue": "^3.5.18",
+        "vue-i18n": "^9.14.5"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.1",
@@ -503,6 +504,50 @@
         "node": ">=18"
       }
     },
+    "node_modules/@intlify/core-base": {
+      "version": "9.14.5",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.14.5.tgz",
+      "integrity": "sha512-5ah5FqZG4pOoHjkvs8mjtv+gPKYU0zCISaYNjBNNqYiaITxW8ZtVih3GS/oTOqN8d9/mDLyrjD46GBApNxmlsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/message-compiler": "9.14.5",
+        "@intlify/shared": "9.14.5"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/message-compiler": {
+      "version": "9.14.5",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.14.5.tgz",
+      "integrity": "sha512-IHzgEu61/YIpQV5Pc3aRWScDcnFKWvQA9kigcINcCBXN8mbW+vk9SK+lDxA6STzKQsVJxUPg9ACC52pKKo3SVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/shared": "9.14.5",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/shared": {
+      "version": "9.14.5",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.14.5.tgz",
+      "integrity": "sha512-9gB+E53BYuAEMhbCAxVgG38EZrk59sxBtv3jSizNL2hEWlgjBjAw1AwpLHtNaeda12pe6W20OGEa0TwuMSRbyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -883,6 +928,12 @@
         "@vue/compiler-dom": "3.5.20",
         "@vue/shared": "3.5.20"
       }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
     },
     "node_modules/@vue/reactivity": {
       "version": "3.5.20",
@@ -1268,6 +1319,26 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-i18n": {
+      "version": "9.14.5",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.14.5.tgz",
+      "integrity": "sha512-0jQ9Em3ymWngyiIkj0+c/k7WgaPO+TNzjKSNq9BvBQaKJECqn9cd9fL4tkDhB5G1QBskGl9YxxbDAhgbFtpe2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "9.14.5",
+        "@intlify/shared": "9.14.5",
+        "@vue/devtools-api": "^6.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "vue": "^3.5.18"
+    "vue": "^3.5.18",
+    "vue-i18n": "^9.14.5"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,9 +5,17 @@
       alt="Asian Mom Pomodoro icon"
       class="home__icon"
     />
-    <button class="home__start">Start pomodoro</button>
+    <button class="home__start">{{ t('start') }}</button>
+    <Settings />
   </div>
 </template>
+
+<script setup>
+import Settings from './components/Settings.vue';
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
+</script>
 
 <style scoped>
 .home {

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="settings">
+    <div class="settings__row">
+      <label for="language">{{ t('language') }}</label>
+      <select id="language" v-model="language">
+        <option value="en">English</option>
+        <option value="ja">日本語</option>
+        <option value="ru">Русский</option>
+      </select>
+    </div>
+    <div class="settings__row">
+      <label for="sendMessage">{{ t('sendMessage') }}</label>
+      <input
+        id="sendMessage"
+        type="checkbox"
+        v-model="sendMessage"
+        class="settings__toggle"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import {
+  getLanguage,
+  setLanguage,
+  getSendMessage,
+  setSendMessage
+} from '../settings';
+
+const { t, locale } = useI18n();
+
+const language = ref(getLanguage());
+const sendMessage = ref(getSendMessage());
+
+locale.value = language.value;
+
+watch(language, (val) => {
+  locale.value = val;
+  setLanguage(val);
+});
+
+watch(sendMessage, (val) => {
+  setSendMessage(val);
+});
+</script>
+
+<style scoped>
+.settings {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.settings__row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+</style>

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,26 @@
+import { createI18n } from 'vue-i18n';
+import { getLanguage } from './settings';
+
+const messages = {
+  en: {
+    start: 'Start pomodoro',
+    language: 'Language',
+    sendMessage: 'Send me message'
+  },
+  ja: {
+    start: 'ポモドーロを開始',
+    language: '言語',
+    sendMessage: 'メッセージを送ってください'
+  },
+  ru: {
+    start: 'Начать помодоро',
+    language: 'Язык',
+    sendMessage: 'Отправлять мне сообщения'
+  }
+};
+
+export default createI18n({
+  legacy: false,
+  locale: getLanguage(),
+  messages
+});

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,8 @@
-import { createApp } from "vue";
-import "./style.css";
-import App from "./App.vue";
+import { createApp } from 'vue';
+import './style.css';
+import App from './App.vue';
+import i18n from './i18n';
 
-createApp(App).mount("#app");
+const app = createApp(App);
+app.use(i18n);
+app.mount('#app');

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,0 +1,30 @@
+const LANGUAGE_KEY = 'language';
+const SEND_MESSAGE_KEY = 'send_message';
+
+function getCookie(name) {
+  const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
+  return match ? decodeURIComponent(match[1]) : '';
+}
+
+function setCookie(name, value, days = 365) {
+  const expires = new Date(Date.now() + days * 864e5).toUTCString();
+  document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/`;
+}
+
+export function getLanguage() {
+  return getCookie(LANGUAGE_KEY) || 'en';
+}
+
+export function setLanguage(lang) {
+  setCookie(LANGUAGE_KEY, lang);
+}
+
+export function getSendMessage() {
+  const value = getCookie(SEND_MESSAGE_KEY);
+  return value ? value === 'true' : false;
+}
+
+export function setSendMessage(val) {
+  setCookie(SEND_MESSAGE_KEY, val);
+}
+


### PR DESCRIPTION
## Summary
- add Settings component with language dropdown and message toggle
- store settings in cookies with helper getters and setters
- configure vue-i18n for English, Japanese and Russian translations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b475ae9e1c8323a76c9f83b990cf91