### PR TITLE
Add temporary notification bar

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -10,6 +10,8 @@
     <p class="home__debug">
       language: {{ cookies.language }}, sendMessage: {{ cookies.sendMessage }}
     </p>
+    <!-- TODO: remove test notification button -->
+    <button class="home__notify" @click="triggerNotification">Test notification</button>
     <Settings @update="updateCookies" />
 
   </div>
@@ -20,6 +22,7 @@ import Settings from './components/Settings.vue';
 import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { getLanguage, getSendMessage } from './settings';
+import { showNotification } from './notification';
 
 const { t } = useI18n();
 
@@ -30,6 +33,13 @@ const cookies = ref({
 
 function updateCookies(val) {
   cookies.value = val;
+}
+
+function triggerNotification() {
+  showNotification({
+    sender: 'Asian Mom',
+    message: 'Ez egy teszt üzenet'
+  });
 }
 
 </script>
@@ -54,6 +64,10 @@ function updateCookies(val) {
 }
 
 .home__debug {
+  margin-top: 1rem;
+}
+
+.home__notify {
   margin-top: 1rem;
 }
 </style>

--- a/src/notification.js
+++ b/src/notification.js
@@ -1,0 +1,74 @@
+export function showNotification({ sender, message }) {
+  const existing = document.getElementById('amp-notification');
+  if (existing) {
+    existing.remove();
+  }
+
+  const container = document.createElement('div');
+  container.id = 'amp-notification';
+  container.style.position = 'fixed';
+  container.style.top = '16px';
+  container.style.right = '-400px';
+  container.style.background = '#FFFFFF';
+  container.style.borderRadius = '8px';
+  container.style.boxShadow = '0 2px 4px rgba(0,0,0,0.2)';
+  container.style.padding = '8px 12px';
+  container.style.display = 'flex';
+  container.style.alignItems = 'center';
+  container.style.gap = '8px';
+  container.style.maxWidth = '300px';
+  container.style.fontFamily = '-apple-system, BlinkMacSystemFont, "San Francisco", Arial, Helvetica, sans-serif';
+  container.style.zIndex = '9999';
+  container.style.transition = 'right 0.3s ease-out';
+  container.style.position = 'fixed';
+
+  const closeBtn = document.createElement('button');
+  closeBtn.textContent = '×';
+  closeBtn.setAttribute('aria-label', 'close notification');
+  closeBtn.style.position = 'absolute';
+  closeBtn.style.top = '4px';
+  closeBtn.style.right = '6px';
+  closeBtn.style.background = 'transparent';
+  closeBtn.style.border = 'none';
+  closeBtn.style.cursor = 'pointer';
+  closeBtn.style.fontSize = '12px';
+  closeBtn.addEventListener('click', () => container.remove());
+
+  const textWrap = document.createElement('div');
+  textWrap.style.display = 'flex';
+  textWrap.style.flexDirection = 'column';
+  textWrap.style.gap = '4px';
+  textWrap.style.marginRight = '8px';
+  textWrap.style.userSelect = 'none';
+
+  const title = document.createElement('div');
+  title.textContent = sender;
+  title.style.fontWeight = '600';
+  title.style.fontSize = '15px';
+  title.style.color = '#000000';
+
+  const msg = document.createElement('div');
+  msg.textContent = message;
+  msg.style.fontWeight = '400';
+  msg.style.fontSize = '14px';
+  msg.style.color = '#333333';
+
+  textWrap.appendChild(title);
+  textWrap.appendChild(msg);
+
+  const icon = document.createElement('img');
+  icon.src = '/assets/img/mom_img.png';
+  icon.alt = 'icon';
+  icon.style.width = '32px';
+  icon.style.height = '32px';
+  icon.style.borderRadius = '50%';
+
+  container.appendChild(closeBtn);
+  container.appendChild(textWrap);
+  container.appendChild(icon);
+
+  document.body.appendChild(container);
+  requestAnimationFrame(() => {
+    container.style.right = '16px';
+  });
+}


### PR DESCRIPTION
## Summary
- implement showNotification function to display slide-in message with icon and close button
- add temporary button on home page to trigger notification for testing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Rollup failed to resolve import "vue-i18n")*

------
https://chatgpt.com/codex/tasks/task_e_68b48bcae93c83238a6c1f977aa4ae6b