### PR TITLE
Add pomodoro timer with cookie-based status

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -4,16 +4,22 @@ import { getLanguage } from './settings';
 const messages = {
   en: {
     start: 'Start pomodoro',
+    stop: 'Stop',
+    restart: 'Restart',
     language: 'Language',
     sendMessage: 'Send me message'
   },
   ja: {
     start: 'ポモドーロを開始',
+    stop: '停止',
+    restart: 'リスタート',
     language: '言語',
     sendMessage: 'メッセージを送ってください'
   },
   ru: {
     start: 'Начать помодоро',
+    stop: 'Стоп',
+    restart: 'Перезапуск',
     language: 'Язык',
     sendMessage: 'Отправлять мне сообщения'
   }

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,5 +1,6 @@
 const LANGUAGE_KEY = 'language';
 const SEND_MESSAGE_KEY = 'send_message';
+const TIMER_STATUS_KEY = 'pomodoro_running';
 
 function getCookie(name) {
   const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
@@ -26,5 +27,14 @@ export function getSendMessage() {
 
 export function setSendMessage(val) {
   setCookie(SEND_MESSAGE_KEY, val);
+}
+
+export function getTimerStatus() {
+  const value = getCookie(TIMER_STATUS_KEY);
+  return value ? value === 'true' : false;
+}
+
+export function setTimerStatus(val) {
+  setCookie(TIMER_STATUS_KEY, val);
 }
 


### PR DESCRIPTION
## Summary
- Implement 4x20 pomodoro timer with 5/15-minute breaks and on-page countdown
- Store running state in cookies with getters and setters
- Add translations and controls for stop and restart actions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b5a1c2ce248323a080f323b9174851