### PR TITLE
Persist pomodoro timer state across extension reloads

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,10 +5,19 @@
       alt="Asian Mom Pomodoro icon"
       class="home__icon"
     />
-    <button class="home__start">{{ t('start') }}</button>
+    <div class="home__timer">{{ formattedTime }}</div>
+    <div v-if="!isStarted">
+      <button class="home__start" @click="startTimer">{{ t('start') }}</button>
+    </div>
+    <div v-else class="home__controls">
+      <button v-if="isRunning" class="home__stop" @click="stopTimer">{{ t('stop') }}</button>
+      <button v-else class="home__start" @click="startTimer">{{ t('start') }}</button>
+      <button class="home__restart" @click="restartTimer">{{ t('restart') }}</button>
+    </div>
     <!-- TODO: remove cookie debug output -->
     <p class="home__debug">
-      language: {{ cookies.language }}, sendMessage: {{ cookies.sendMessage }}
+      language: {{ cookies.language }}, sendMessage: {{ cookies.sendMessage }}, pomodoroRunning: {{ cookies.pomodoroRunning }},
+      pomodoroStarted: {{ cookies.pomodoroStarted }}, pomodoroStart: {{ cookies.pomodoroStart }}, pomodoroElapsed: {{ cookies.pomodoroElapsed }}
     </p>
     <Settings @update="updateCookies" />
 
@@ -17,19 +26,142 @@
 
 <script setup>
 import Settings from './components/Settings.vue';
-import { ref } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { getLanguage, getSendMessage } from './settings';
+import {
+  getLanguage,
+  getSendMessage,
+  getTimerStatus,
+  setTimerStatus,
+  getTimerStarted,
+  setTimerStarted,
+  getTimerStartTime,
+  setTimerStartTime,
+  getTimerElapsed,
+  setTimerElapsed
+} from './settings';
 
 const { t } = useI18n();
 
 const cookies = ref({
   language: getLanguage(),
-  sendMessage: getSendMessage()
+  sendMessage: getSendMessage(),
+  pomodoroRunning: getTimerStatus(),
+  pomodoroStarted: getTimerStarted(),
+  pomodoroStart: getTimerStartTime(),
+  pomodoroElapsed: getTimerElapsed()
+});
+
+const stages = [20 * 60, 5 * 60, 20 * 60, 5 * 60, 20 * 60, 5 * 60, 20 * 60, 15 * 60];
+const totalDuration = stages.reduce((a, b) => a + b, 0) * 1000;
+const currentStage = ref(0);
+const timeLeft = ref(stages[0]);
+const isRunning = ref(getTimerStatus());
+const isStarted = ref(getTimerStarted());
+const startTime = ref(getTimerStartTime());
+const elapsedWhenStopped = ref(getTimerElapsed());
+let intervalId = null;
+
+const formattedTime = computed(() => {
+  const m = Math.floor(timeLeft.value / 60);
+  const s = timeLeft.value % 60;
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+});
+
+function calculate() {
+  if (!isStarted.value) {
+    currentStage.value = 0;
+    timeLeft.value = stages[0];
+    return;
+  }
+
+  let elapsed = isRunning.value
+    ? Date.now() - startTime.value
+    : elapsedWhenStopped.value;
+
+  if (elapsed >= totalDuration) {
+    restartTimer();
+    return;
+  }
+
+  let idx = 0;
+  let remaining = elapsed;
+  while (remaining >= stages[idx] * 1000) {
+    remaining -= stages[idx] * 1000;
+    idx++;
+  }
+  currentStage.value = idx;
+  timeLeft.value = Math.ceil((stages[idx] * 1000 - remaining) / 1000);
+}
+
+function startTimer() {
+  if (intervalId) clearInterval(intervalId);
+
+  if (isStarted.value && !isRunning.value) {
+    startTime.value = Date.now() - elapsedWhenStopped.value;
+  } else {
+    startTime.value = Date.now();
+    elapsedWhenStopped.value = 0;
+  }
+
+  isRunning.value = true;
+  isStarted.value = true;
+  setTimerStatus(true);
+  setTimerStarted(true);
+  setTimerStartTime(startTime.value);
+  setTimerElapsed(elapsedWhenStopped.value);
+  Object.assign(cookies.value, {
+    pomodoroRunning: true,
+    pomodoroStarted: true,
+    pomodoroStart: startTime.value,
+    pomodoroElapsed: elapsedWhenStopped.value
+  });
+
+  calculate();
+  intervalId = setInterval(calculate, 1000);
+}
+
+function stopTimer() {
+  clearInterval(intervalId);
+  elapsedWhenStopped.value = Date.now() - startTime.value;
+  isRunning.value = false;
+  setTimerStatus(false);
+  setTimerElapsed(elapsedWhenStopped.value);
+  cookies.value.pomodoroRunning = false;
+  cookies.value.pomodoroElapsed = elapsedWhenStopped.value;
+}
+
+function restartTimer() {
+  clearInterval(intervalId);
+  currentStage.value = 0;
+  timeLeft.value = stages[0];
+  isRunning.value = false;
+  isStarted.value = false;
+  startTime.value = 0;
+  elapsedWhenStopped.value = 0;
+  setTimerStatus(false);
+  setTimerStarted(false);
+  setTimerStartTime(0);
+  setTimerElapsed(0);
+  Object.assign(cookies.value, {
+    pomodoroRunning: false,
+    pomodoroStarted: false,
+    pomodoroStart: 0,
+    pomodoroElapsed: 0
+  });
+}
+
+onMounted(() => {
+  if (isStarted.value) {
+    calculate();
+    if (isRunning.value) {
+      intervalId = setInterval(calculate, 1000);
+    }
+  }
 });
 
 function updateCookies(val) {
-  cookies.value = val;
+  cookies.value = { ...cookies.value, ...val };
 }
 
 </script>
@@ -54,6 +186,11 @@ function updateCookies(val) {
 }
 
 .home__debug {
+  margin-top: 1rem;
+}
+
+.home__timer {
+  font-size: 2rem;
   margin-top: 1rem;
 }
 </style>

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -4,16 +4,22 @@ import { getLanguage } from './settings';
 const messages = {
   en: {
     start: 'Start pomodoro',
+    stop: 'Stop',
+    restart: 'Restart',
     language: 'Language',
     sendMessage: 'Send me message'
   },
   ja: {
     start: 'ポモドーロを開始',
+    stop: '停止',
+    restart: 'リスタート',
     language: '言語',
     sendMessage: 'メッセージを送ってください'
   },
   ru: {
     start: 'Начать помодоро',
+    stop: 'Стоп',
+    restart: 'Перезапуск',
     language: 'Язык',
     sendMessage: 'Отправлять мне сообщения'
   }

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,5 +1,9 @@
 const LANGUAGE_KEY = 'language';
 const SEND_MESSAGE_KEY = 'send_message';
+const TIMER_STATUS_KEY = 'pomodoro_running';
+const TIMER_STARTED_KEY = 'pomodoro_started';
+const TIMER_START_TIME_KEY = 'pomodoro_start_time';
+const TIMER_ELAPSED_KEY = 'pomodoro_elapsed';
 
 function getCookie(name) {
   const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
@@ -26,5 +30,41 @@ export function getSendMessage() {
 
 export function setSendMessage(val) {
   setCookie(SEND_MESSAGE_KEY, val);
+}
+
+export function getTimerStatus() {
+  const value = getCookie(TIMER_STATUS_KEY);
+  return value ? value === 'true' : false;
+}
+
+export function setTimerStatus(val) {
+  setCookie(TIMER_STATUS_KEY, val);
+}
+
+export function getTimerStarted() {
+  const value = getCookie(TIMER_STARTED_KEY);
+  return value ? value === 'true' : false;
+}
+
+export function setTimerStarted(val) {
+  setCookie(TIMER_STARTED_KEY, val);
+}
+
+export function getTimerStartTime() {
+  const value = getCookie(TIMER_START_TIME_KEY);
+  return value ? parseInt(value) : 0;
+}
+
+export function setTimerStartTime(val) {
+  setCookie(TIMER_START_TIME_KEY, val);
+}
+
+export function getTimerElapsed() {
+  const value = getCookie(TIMER_ELAPSED_KEY);
+  return value ? parseInt(value) : 0;
+}
+
+export function setTimerElapsed(val) {
+  setCookie(TIMER_ELAPSED_KEY, val);
 }
 


### PR DESCRIPTION
## Summary
- Track timer start time and elapsed duration in cookies to restore countdown when popup closes
- Compute remaining time by comparing current time to stored start time so stages advance in background
- Add cookie helpers for started/start time/elapsed and expose them in debug output

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5a1c2ce248323a080f323b9174851