### PR TITLE
Add toast notifications with background timer

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -12,7 +12,7 @@
     }
   },
   "background": {
-    "service_worker": "background.js",
+    "service_worker": "src/background.js",
     "type": "module"
   },
   "icons": {
@@ -24,10 +24,11 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["content.js"],
+      "js": ["src/contentScript.js"],
       "run_at": "document_idle"
     }
   ],
-  "permissions": ["storage"],
+  "permissions": ["scripting", "alarms", "notifications"],
   "host_permissions": ["<all_urls>"]
 }
+

--- a/src/App.vue
+++ b/src/App.vue
@@ -29,6 +29,14 @@
     </p>
     Is in focus ? => {{ currentStage % 2 === 0 }}
     <Settings @update="updateCookies" />
+    <div class="toast-demo">
+      <button class="toast-demo__btn" @click="triggerToast">
+        Mutasd a toastot
+      </button>
+      <button class="toast-demo__btn" @click="startToastTimer">
+        Indíts 10 mp-es időzítőt
+      </button>
+    </div>
   </div>
 </template>
 
@@ -198,6 +206,20 @@ onMounted(() => {
 function updateCookies(val) {
   cookies.value = { ...cookies.value, ...val };
 }
+
+function triggerToast() {
+  chrome.runtime.sendMessage({
+    type: "TRIGGER_TOAST",
+    text: "👋 Egyedi, CSS-es toast!",
+  });
+}
+
+function startToastTimer() {
+  chrome.runtime.sendMessage({
+    type: "START_TIMER",
+    delayMs: 10000,
+  });
+}
 </script>
 
 <style scoped>
@@ -226,5 +248,15 @@ function updateCookies(val) {
 .home__timer {
   font-size: 2rem;
   margin-top: 1rem;
+}
+
+.toast-demo {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.toast-demo__btn {
+  padding: 0.5rem 1rem;
 }
 </style>

--- a/src/background.js
+++ b/src/background.js
@@ -1,0 +1,36 @@
+async function getActiveTab() {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  return tab;
+}
+
+async function sendToastToActiveTab(text) {
+  const tab = await getActiveTab();
+  if (tab && tab.id !== undefined) {
+    chrome.tabs.sendMessage(tab.id, { type: "SHOW_TOAST", text });
+  }
+}
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.type === "TRIGGER_TOAST") {
+    sendToastToActiveTab(message.text);
+  } else if (message.type === "START_TIMER") {
+    const delayMs = Number(message.delayMs) || 0;
+    chrome.alarms.create("toastAlarm", { when: Date.now() + delayMs });
+  } else if (message.type === "SYSTEM_NOTIFICATION") {
+    chrome.notifications.create({
+      type: "basic",
+      iconUrl: "assets/img/icon.png",
+      title: "Asian Mom Pomodoro",
+      message: message.text || ""
+    });
+  }
+});
+
+chrome.alarms.onAlarm.addListener((alarm) => {
+  if (alarm.name === "toastAlarm") {
+    sendToastToActiveTab("⏰ Időzítő lejárt – itt a toast!");
+  }
+});
+
+export {};
+

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -1,0 +1,54 @@
+function ensureContainer() {
+  let container = document.getElementById("__amp-toast-container");
+  if (!container) {
+    container = document.createElement("div");
+    container.id = "__amp-toast-container";
+    Object.assign(container.style, {
+      position: "fixed",
+      bottom: "20px",
+      left: "50%",
+      transform: "translateX(-50%)",
+      zIndex: "2147483647",
+      pointerEvents: "none"
+    });
+    document.body.appendChild(container);
+  }
+  return container;
+}
+
+function showToast(text) {
+  const container = ensureContainer();
+  const toast = document.createElement("div");
+  toast.textContent = text;
+  Object.assign(toast.style, {
+    background: "rgba(0,0,0,0.85)",
+    color: "#fff",
+    padding: "8px 16px",
+    borderRadius: "4px",
+    boxShadow: "0 2px 6px rgba(0,0,0,0.3)",
+    marginTop: "8px",
+    opacity: "0",
+    transform: "translateY(20px)",
+    transition: "opacity 0.3s, transform 0.3s",
+    pointerEvents: "auto"
+  });
+  container.appendChild(toast);
+  requestAnimationFrame(() => {
+    toast.style.opacity = "1";
+    toast.style.transform = "translateY(0)";
+  });
+  setTimeout(() => {
+    toast.style.opacity = "0";
+    toast.style.transform = "translateY(20px)";
+    setTimeout(() => toast.remove(), 300);
+  }, 4000);
+}
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.type === "SHOW_TOAST") {
+    showToast(message.text);
+  }
+});
+
+export {};
+


### PR DESCRIPTION
## Summary
- add MV3 service worker and content script to show CSS toast notifications
- wire popup buttons to trigger immediate and delayed toasts
- update manifest for new scripts and permissions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5d86f10008323b4509d05bc702398