### PR TITLE
feat: open stage tab with action button

### DIFF
--- a/public/background.js
+++ b/public/background.js
@@ -51,7 +51,17 @@ async function sendToActiveTabWithInjection(msg) {
 const focusMessages = ["Ideje koncentrálni!", "Rajta, fókuszálj!"];
 const breakMessages = ["Itt a szünet ideje!", "Pihenj egy kicsit!"];
 
+function openStageTab(stageIndex) {
+  // odd index -> break, even index -> work
+  const mode = stageIndex % 2 === 1 ? "break" : "work";
+  const url = chrome.runtime.getURL(`stage.html?mode=${mode}`);
+  chrome.tabs.create({ url, active: true });
+}
+
 function sendStageNotification(stageIndex) {
+  if (stageIndex > 0) {
+    openStageTab(stageIndex);
+  }
   const msgs = stageIndex % 2 === 0 ? focusMessages : breakMessages;
   const message = msgs[Math.floor(Math.random() * msgs.length)];
   sendToActiveTabWithInjection({
@@ -118,6 +128,9 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       sendResponse({ ok: true });
     } else if (msg?.type === "CLEAR_POMODORO_ALARMS") {
       await clearPomodoroAlarms();
+      sendResponse({ ok: true });
+    } else if (msg?.type === "STAGE_ACTION") {
+      console.log("Stage action received:", msg.stage);
       sendResponse({ ok: true });
     }
   })();

--- a/public/stage.html
+++ b/public/stage.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Asian Mom Pomodoro</title>
+  <style>
+    body {
+      margin: 0;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      font-family: system-ui, sans-serif;
+    }
+    button {
+      font-size: 2rem;
+      padding: 1rem 2rem;
+      border-radius: 8px;
+      border: 1px solid #ccc;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+  <button id="actionButton"></button>
+  <script type="module" src="stage.js"></script>
+</body>
+</html>

--- a/public/stage.js
+++ b/public/stage.js
@@ -1,0 +1,27 @@
+const translations = {
+  en: { startBreak: 'Start break', startWork: 'Start work' },
+  ja: { startBreak: '休憩を開始', startWork: '作業を開始' },
+  ru: { startBreak: 'Начать перерыв', startWork: 'Начать работу' }
+};
+
+function getCookie(name) {
+  const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
+  return match ? decodeURIComponent(match[1]) : '';
+}
+
+function getLanguage() {
+  return getCookie('language') || 'en';
+}
+
+const params = new URLSearchParams(location.search);
+const mode = params.get('mode') === 'break' ? 'break' : 'work';
+const lang = getLanguage();
+const t = translations[lang] || translations.en;
+
+const btn = document.getElementById('actionButton');
+btn.textContent = mode === 'break' ? t.startBreak : t.startWork;
+
+btn.addEventListener('click', () => {
+  chrome.runtime.sendMessage({ type: 'STAGE_ACTION', stage: mode });
+  window.close();
+});


### PR DESCRIPTION
## Summary
- open a new Chrome tab showing a stage page whenever the Pomodoro stage changes
- add stage page displaying a big "Start break" or "Start work" button based on language
- log stage action messages from the new page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b704e3274c83238247bec33b44884a