### PR TITLE
feat: redesign stage popup

### DIFF
--- a/public/stage.html
+++ b/public/stage.html
@@ -7,14 +7,25 @@
     body {
       margin: 0;
       display: flex;
+      flex-direction: column;
       justify-content: center;
       align-items: center;
       height: 100vh;
       font-family: system-ui, sans-serif;
+      text-align: center;
+    }
+    img {
+      max-width: 200px;
+      height: auto;
+    }
+    #countdown {
+      font-weight: bold;
+      font-size: 2rem;
     }
     button {
-      font-size: 2rem;
-      padding: 1rem 2rem;
+      margin-top: 20px;
+      font-size: 1.5rem;
+      padding: 0.5rem 1rem;
       border-radius: 8px;
       border: 1px solid #ccc;
       cursor: pointer;
@@ -22,7 +33,10 @@
   </style>
 </head>
 <body>
-  <button id="actionButton"></button>
+  <img src="assets/img/mom_img.png" alt="Asian mom" id="momImage" />
+  <h2 id="stageTitle"></h2>
+  <div id="countdown"></div>
+  <button id="okButton">Ok</button>
   <script type="module" src="stage.js"></script>
 </body>
 </html>

--- a/public/stage.js
+++ b/public/stage.js
@@ -1,33 +1,85 @@
-const translations = {
-  en: { startBreak: 'Start break', startWork: 'Start work' },
-  ja: { startBreak: '休憩を開始', startWork: '作業を開始' },
-  ru: { startBreak: 'Начать перерыв', startWork: 'Начать работу' }
-};
+const params = new URLSearchParams(location.search);
+const mode = params.get('mode') === 'break' ? 'break' : 'work';
+
+const titleEl = document.getElementById('stageTitle');
+const countdownEl = document.getElementById('countdown');
+const okBtn = document.getElementById('okButton');
+
+titleEl.textContent = mode === 'break' ? 'Start your break' : 'Work';
+countdownEl.style.color = mode === 'break' ? 'red' : 'green';
+
+const stages = [
+  1 * 60, // fokus
+  1 * 60,
+  1 * 60, // fokus
+  1 * 60,
+  1 * 60, // fokus
+  1 * 60,
+  1 * 60, // fokus
+  15 * 60,
+];
+const totalDuration = stages.reduce((a, b) => a + b, 0) * 1000;
 
 function getCookie(name) {
   const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
   return match ? decodeURIComponent(match[1]) : '';
 }
 
-/**
- * Visszaadja a felhasználó nyelvét a `language` cookie alapján, ha nincs beállítva,
- * akkor az angolt (`'en'`) használja alapértelmezetten. Nem vár paramétert.
- *
- * @returns {string} A nyelvi kód.
- */
-function getLanguage() {
-  return getCookie('language') || 'en';
+function getTimerStarted() {
+  const value = getCookie('pomodoro_started');
+  return value ? value === 'true' : false;
 }
 
-const params = new URLSearchParams(location.search);
-const mode = params.get('mode') === 'break' ? 'break' : 'work';
-const lang = getLanguage();
-const t = translations[lang] || translations.en;
+function getTimerStatus() {
+  const value = getCookie('pomodoro_running');
+  return value ? value === 'true' : false;
+}
 
-const btn = document.getElementById('actionButton');
-btn.textContent = mode === 'break' ? t.startBreak : t.startWork;
+function getTimerStartTime() {
+  const value = getCookie('pomodoro_start_time');
+  return value ? parseInt(value) : 0;
+}
 
-btn.addEventListener('click', () => {
+function getTimerElapsed() {
+  const value = getCookie('pomodoro_elapsed');
+  return value ? parseInt(value) : 0;
+}
+
+function getTimeLeft() {
+  if (!getTimerStarted()) {
+    return stages[0];
+  }
+
+  const startTime = getTimerStartTime();
+  const elapsedWhenStopped = getTimerElapsed();
+  const isRunning = getTimerStatus();
+
+  let elapsed = isRunning ? Date.now() - startTime : elapsedWhenStopped;
+
+  if (elapsed >= totalDuration) {
+    return stages[0];
+  }
+
+  let idx = 0;
+  let remaining = elapsed;
+  while (remaining >= stages[idx] * 1000) {
+    remaining -= stages[idx] * 1000;
+    idx++;
+  }
+  return Math.ceil((stages[idx] * 1000 - remaining) / 1000);
+}
+
+function updateCountdown() {
+  const remaining = getTimeLeft();
+  const m = String(Math.floor(remaining / 60)).padStart(2, '0');
+  const s = String(remaining % 60).padStart(2, '0');
+  countdownEl.textContent = `${m}:${s}`;
+}
+
+updateCountdown();
+setInterval(updateCountdown, 1000);
+
+okBtn.addEventListener('click', () => {
   chrome.runtime.sendMessage({ type: 'STAGE_ACTION', stage: mode });
   window.close();
 });


### PR DESCRIPTION
## Summary
- redesign stage popup with centered image, status text, colored countdown, and Ok button
- reuse existing mom_img.png and remove added mam_img.png binary asset
- expose only mom_img.png in manifest web_accessible_resources
- sync stage popup countdown with popup's timer using shared cookie-based remaining time calculation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b730103f9083238395ba9c1bd58018