### PR TITLE
Add optional session sound effect toggle

### DIFF
--- a/public/stage.js
+++ b/public/stage.js
@@ -8,6 +8,16 @@ const okBtn = document.getElementById("okButton");
 titleEl.textContent = mode === "break" ? "Start your break" : "Work";
 countdownEl.style.color = mode === "break" ? "green" : "red";
 
+function getPlaySound() {
+  const value = readCookie("sound_enabled");
+  return value ? value === "true" : false;
+}
+
+if (getPlaySound()) {
+  const audio = new Audio(`/assets/sounds/${mode}.mp3`);
+  audio.play().catch(() => {});
+}
+
 const stages = [
   1 * 60, // fokus
   1 * 60,

--- a/src/App.vue
+++ b/src/App.vue
@@ -25,6 +25,7 @@
     <!-- TODO: remove cookie debug output -->
     <p class="home__debug">
       language: {{ cookies.language }}, sendMessage: {{ cookies.sendMessage }},
+      playSound: {{ cookies.playSound }},
       pomodoroRunning: {{ cookies.pomodoroRunning }}, pomodoroStarted:
       {{ cookies.pomodoroStarted }}, pomodoroStart: {{ cookies.pomodoroStart }},
       pomodoroElapsed: {{ cookies.pomodoroElapsed }}
@@ -41,6 +42,7 @@ import { useI18n } from "vue-i18n";
 import {
   getLanguage,
   getSendMessage,
+  getPlaySound,
   getTimerStatus,
   setTimerStatus,
   getTimerStarted,
@@ -56,6 +58,7 @@ const { t } = useI18n();
 const cookies = ref({
   language: getLanguage(),
   sendMessage: getSendMessage(),
+  playSound: getPlaySound(),
   pomodoroRunning: getTimerStatus(),
   pomodoroStarted: getTimerStarted(),
   pomodoroStart: getTimerStartTime(),

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -17,6 +17,15 @@
         class="settings__toggle"
       />
     </div>
+    <div class="settings__row">
+      <label for="playSound">{{ t('playSound') }}</label>
+      <input
+        id="playSound"
+        type="checkbox"
+        v-model="playSound"
+        class="settings__toggle"
+      />
+    </div>
   </div>
 </template>
 
@@ -27,7 +36,9 @@ import {
   getLanguage,
   setLanguage,
   getSendMessage,
-  setSendMessage
+  setSendMessage,
+  getPlaySound,
+  setPlaySound
 } from '../settings';
 
 const { t, locale } = useI18n();
@@ -36,20 +47,24 @@ const emit = defineEmits(['update']);
 
 const language = ref(getLanguage());
 const sendMessage = ref(getSendMessage());
+const playSound = ref(getPlaySound());
 
 locale.value = language.value;
 
 watch(language, (val) => {
   locale.value = val;
   setLanguage(val);
-  emit('update', { language: val, sendMessage: sendMessage.value });
-
+  emit('update', { language: val, sendMessage: sendMessage.value, playSound: playSound.value });
 });
 
 watch(sendMessage, (val) => {
   setSendMessage(val);
-  emit('update', { language: language.value, sendMessage: val });
+  emit('update', { language: language.value, sendMessage: val, playSound: playSound.value });
+});
 
+watch(playSound, (val) => {
+  setPlaySound(val);
+  emit('update', { language: language.value, sendMessage: sendMessage.value, playSound: val });
 });
 </script>
 

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -7,21 +7,24 @@ const messages = {
     stop: 'Stop',
     restart: 'Restart',
     language: 'Language',
-    sendMessage: 'Send me message'
+    sendMessage: 'Send me message',
+    playSound: 'Play sound effect'
   },
   ja: {
     start: 'ポモドーロを開始',
     stop: '停止',
     restart: 'リスタート',
     language: '言語',
-    sendMessage: 'メッセージを送ってください'
+    sendMessage: 'メッセージを送ってください',
+    playSound: '効果音を再生'
   },
   ru: {
     start: 'Начать помодоро',
     stop: 'Стоп',
     restart: 'Перезапуск',
     language: 'Язык',
-    sendMessage: 'Отправлять мне сообщения'
+    sendMessage: 'Отправлять мне сообщения',
+    playSound: 'Воспроизводить звук'
   }
 };
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,5 +1,6 @@
 const LANGUAGE_KEY = 'language';
 const SEND_MESSAGE_KEY = 'send_message';
+const SOUND_ENABLED_KEY = 'sound_enabled';
 const TIMER_STATUS_KEY = 'pomodoro_running';
 const TIMER_STARTED_KEY = 'pomodoro_started';
 const TIMER_START_TIME_KEY = 'pomodoro_start_time';
@@ -81,6 +82,30 @@ export function getSendMessage() {
  */
 export function setSendMessage(val) {
   setCookie(SEND_MESSAGE_KEY, val);
+}
+
+/**
+ * Hangjelzés engedélyezésének lekérése.
+ *
+ * Visszatérési érték:
+ *   boolean: True, ha engedélyezett a hang.
+ */
+export function getPlaySound() {
+  const value = getCookie(SOUND_ENABLED_KEY);
+  return value ? value === 'true' : false;
+}
+
+/**
+ * Hangjelzés engedélyezésének mentése.
+ *
+ * Paraméterek:
+ *   val (boolean): Engedélyezett legyen-e a hang.
+ *
+ * Visszatérési érték:
+ *   void: Nem ad vissza értéket.
+ */
+export function setPlaySound(val) {
+  setCookie(SOUND_ENABLED_KEY, val);
 }
 
 /**


### PR DESCRIPTION
## Summary
- add sound preference stored in cookie and settings module
- expose "Play sound effect" toggle in settings UI
- play work/break sound when stage popup opens

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7e0f330c48323b1d40f99cc8e0c32