### PR TITLE
feat: notify on distracting sites

### DIFF
--- a/public/background.js
+++ b/public/background.js
@@ -71,6 +71,70 @@ async function sendToActiveTabWithInjection(msg) {
   }
 }
 
+/**
+ * Sütiérték lekérése az extension domainjén.
+ *
+ * Paraméterek:
+ *   name (string): A süti kulcsa.
+ *
+ * Visszatérési érték:
+ *   Promise<string|null>: A süti értéke vagy null.
+ */
+async function getExtensionCookie(name) {
+  const url = chrome.runtime.getURL("/");
+  const cookie = await chrome.cookies.get({ url, name });
+  return cookie ? cookie.value : null;
+}
+
+// ---------- Distraktor oldalak figyelése ----------
+const DISTRACTOR_DOMAINS = ["facebook.com", "instagram.com", "reddit.com"];
+
+/**
+ * Zavaró oldalak felismerése és értesítés kérése.
+ *
+ * Megnézi az aktív fül domainjét, és ha az szerepel a
+ * DISTRACTOR_DOMAINS listában, fut a fókusz mód és engedélyezett az üzenetküldés,
+ * üzenetet küld a tartalom scriptnek.
+ *
+ * Visszatérési érték:
+ *   Promise<void>: Nem ad vissza értéket.
+ */
+async function notifyOnDistractingSite() {
+  const tab = await getActiveHttpTab();
+  if (!tab) return;
+
+  let hostname;
+  try {
+    hostname = new URL(tab.url).hostname.replace(/^www\./, "");
+  } catch (e) {
+    console.warn("URL parsing failed:", e);
+    return;
+  }
+
+  if (DISTRACTOR_DOMAINS.includes(hostname)) {
+    const [started, running, sendMessage] = await Promise.all([
+      getExtensionCookie("pomodoro_started"),
+      getExtensionCookie("pomodoro_running"),
+      getExtensionCookie("send_message"),
+    ]);
+    if (started === "true" && running === "true" && sendMessage === "true") {
+      // TODO: Válaszd ki az üzenetet domain és fókusz/pihenő állapot alapján
+      const message = "Biztos, hogy ez most segít a céljaidban?";
+      await sendToActiveTabWithInjection({
+        type: "SHOW_WHATSAPP_NOTIFICATION",
+        payload: { sender: "Asian Mom", message },
+      });
+    }
+  }
+}
+
+chrome.tabs.onActivated.addListener(notifyOnDistractingSite);
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (tab.active && changeInfo.status === "complete") {
+    notifyOnDistractingSite();
+  }
+});
+
 // ---------- Pomodoro notification scheduling ----------
 const focusMessages = ["Ideje koncentrálni!", "Rajta, fókuszálj!"];
 const breakMessages = ["Itt a szünet ideje!", "Pihenj egy kicsit!"];

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -34,7 +34,8 @@
     "notifications",
     "scripting",
     "tabs",
-    "windows"
+    "windows",
+    "cookies"
   ],
   "host_permissions": ["<all_urls>"],
   "web_accessible_resources": [


### PR DESCRIPTION
## Summary
- detect active tab for distracting domains and trigger notifications only when pomodoro focus session is running
- add helper to read extension cookies and include `cookies` permission for background access
- add TODO for future site/session message selection
- gate distracting-site notifications behind `send_message` cookie

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7fc5d6de883238d3cf8c6da4930b0