### PR TITLE
feat: notify on distracting sites

### DIFF
--- a/public/background.js
+++ b/public/background.js
@@ -71,6 +71,72 @@ async function sendToActiveTabWithInjection(msg) {
   }
 }
 
+/**
+ * Sütiérték lekérése a storage-ből (cookie elérés helyett).
+ *
+ * Paraméterek:
+ *   name (string): A kulcs neve.
+ *
+ * Visszatérési érték:
+ *   Promise<string|null>: A tárolt érték vagy null.
+ */
+async function getExtensionFlag(name) {
+  return new Promise((resolve) => {
+    chrome.storage.local.get([name], (result) => {
+      resolve(result[name] ?? null);
+    });
+  });
+}
+
+// ---------- Distraktor oldalak figyelése ----------
+const DISTRACTOR_DOMAINS = ["facebook.com", "instagram.com", "reddit.com"];
+
+/**
+ * Zavaró oldalak felismerése és értesítés kérése.
+ *
+ * Megnézi az aktív fül domainjét, és ha az szerepel a
+ * DISTRACTOR_DOMAINS listában, fut a fókusz mód és engedélyezett az üzenetküldés,
+ * üzenetet küld a tartalom scriptnek.
+ *
+ * Visszatérési érték:
+ *   Promise<void>: Nem ad vissza értéket.
+ */
+async function notifyOnDistractingSite() {
+  const tab = await getActiveHttpTab();
+  if (!tab) return;
+
+  let hostname;
+  try {
+    hostname = new URL(tab.url).hostname.replace(/^www\./, "");
+  } catch (e) {
+    console.warn("URL parsing failed:", e);
+    return;
+  }
+
+  if (DISTRACTOR_DOMAINS.includes(hostname)) {
+    const [started, running, sendMessage] = await Promise.all([
+      getExtensionFlag("pomodoro_started"),
+      getExtensionFlag("pomodoro_running"),
+      getExtensionFlag("send_message"),
+    ]);
+    if (started === "true" && running === "true" && sendMessage === "true") {
+      // TODO: Válaszd ki az üzenetet domain és fókusz/pihenő állapot alapján
+      const message = "Biztos, hogy ez most segít a céljaidban?";
+      await sendToActiveTabWithInjection({
+        type: "SHOW_WHATSAPP_NOTIFICATION",
+        payload: { sender: "Asian Mom", message },
+      });
+    }
+  }
+}
+
+chrome.tabs.onActivated.addListener(notifyOnDistractingSite);
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (tab.active && changeInfo.status === "complete") {
+    notifyOnDistractingSite();
+  }
+});
+
 // ---------- Pomodoro notification scheduling ----------
 const focusMessages = ["Ideje koncentrálni!", "Rajta, fókuszálj!"];
 const breakMessages = ["Itt a szünet ideje!", "Pihenj egy kicsit!"];

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -34,7 +34,8 @@
     "notifications",
     "scripting",
     "tabs",
-    "windows"
+    "windows",
+    "cookies"
   ],
   "host_permissions": ["<all_urls>"],
   "web_accessible_resources": [

--- a/src/settings.js
+++ b/src/settings.js
@@ -22,7 +22,7 @@ function getCookie(name) {
 }
 
 /**
- * Süti beállítása adott kulccsal és értékkel.
+ * Süti beállítása adott kulccsal és értékkel, és szinkronizálása storage-be.
  *
  * Paraméterek:
  *   name (string): A süti neve.
@@ -35,6 +35,9 @@ function getCookie(name) {
 function setCookie(name, value, days = 365) {
   const expires = new Date(Date.now() + days * 864e5).toUTCString();
   document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/`;
+  if (chrome?.storage?.local) {
+    chrome.storage.local.set({ [name]: String(value) });
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- detect active tab for distracting domains and trigger notifications only when pomodoro focus session is running
- add helper to read extension cookies and include `cookies` permission for background access
- add TODO for future site/session message selection
- gate distracting-site notifications behind `send_message` cookie
- store cookie flags in `chrome.storage` for safe background access

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7fc5d6de883238d3cf8c6da4930b0