### PR TITLE
feat: notify on distracting sites

### DIFF
--- a/public/background.js
+++ b/public/background.js
@@ -71,6 +71,59 @@ async function sendToActiveTabWithInjection(msg) {
   }
 }
 
+// ---------- Distraktor oldalak figyelése ----------
+const DISTRACTOR_DOMAINS = ["facebook.com", "instagram.com", "reddit.com"];
+
+/**
+ * Zavaró oldalak felismerése és értesítés kérése.
+ *
+ * Megnézi az aktív fül domainjét, és ha az szerepel a
+ * DISTRACTOR_DOMAINS listában, fut a fókusz mód és engedélyezett az üzenetküldés,
+ * üzenetet küld a tartalom scriptnek.
+ *
+ * Visszatérési érték:
+ *   Promise<void>: Nem ad vissza értéket.
+ */
+async function notifyOnDistractingSite() {
+  const tab = await getActiveHttpTab();
+  if (!tab) return;
+
+  let hostname;
+  try {
+    hostname = new URL(tab.url).hostname.replace(/^www\./, "");
+  } catch (e) {
+    console.warn("URL parsing failed:", e);
+    return;
+  }
+
+  if (DISTRACTOR_DOMAINS.includes(hostname)) {
+    const {
+      pomodoro_started: started,
+      pomodoro_running: running,
+      send_message: sendMessage,
+    } = await chrome.storage.local.get([
+      "pomodoro_started",
+      "pomodoro_running",
+      "send_message",
+    ]);
+    if (started === "true" && running === "true" && sendMessage === "true") {
+      // TODO: Válaszd ki az üzenetet domain és fókusz/pihenő állapot alapján
+      const message = "Biztos, hogy ez most segít a céljaidban?";
+      await sendToActiveTabWithInjection({
+        type: "SHOW_WHATSAPP_NOTIFICATION",
+        payload: { sender: "Asian Mom", message },
+      });
+    }
+  }
+}
+
+chrome.tabs.onActivated.addListener(notifyOnDistractingSite);
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (tab.active && changeInfo.status === "complete") {
+    notifyOnDistractingSite();
+  }
+});
+
 // ---------- Pomodoro notification scheduling ----------
 const focusMessages = ["Ideje koncentrálni!", "Rajta, fókuszálj!"];
 const breakMessages = ["Itt a szünet ideje!", "Pihenj egy kicsit!"];

--- a/src/settings.js
+++ b/src/settings.js
@@ -22,7 +22,7 @@ function getCookie(name) {
 }
 
 /**
- * Süti beállítása adott kulccsal és értékkel.
+ * Süti beállítása adott kulccsal és értékkel, és szinkronizálása storage-be.
  *
  * Paraméterek:
  *   name (string): A süti neve.
@@ -35,6 +35,9 @@ function getCookie(name) {
 function setCookie(name, value, days = 365) {
   const expires = new Date(Date.now() + days * 864e5).toUTCString();
   document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/`;
+  if (chrome?.storage?.local) {
+    chrome.storage.local.set({ [name]: String(value) });
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- read pomodoro flags from `chrome.storage` in background worker to avoid cookie permission errors
- drop unused `cookies` permission

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7fc5d6de883238d3cf8c6da4930b0