### PR TITLE
feat: add pomodoro service worker

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
-  "name": "My Vite + Vue Chrome Extension",
+  "name": "Asian Mom Pomodoro",
   "version": "0.1.0",
-  "description": "Vite + Vue popup, külön JS logikával (background/content).",
+  "description": "Simple Pomodoro timer with badge updates.",
   "action": {
     "default_popup": "index.html",
     "default_title": "Open Popup",
@@ -12,8 +12,7 @@
     }
   },
   "background": {
-    "service_worker": "background.js",
-    "type": "module"
+    "service_worker": "sw.js"
   },
   "icons": {
     "16": "assets/img/icon.png",
@@ -21,27 +20,5 @@
     "48": "assets/img/icon.png",
     "128": "assets/img/icon.png"
   },
-  "content_scripts": [
-    {
-      "matches": ["<all_urls>"],
-      "js": ["content.js"],
-      "run_at": "document_idle"
-    }
-  ],
-  "permissions": [
-    "storage",
-    "alarms",
-    "notifications",
-    "scripting",
-    "tabs",
-    "windows",
-    "cookies"
-  ],
-  "host_permissions": ["<all_urls>"],
-  "web_accessible_resources": [
-    {
-      "resources": ["assets/img/mom_img.png"],
-      "matches": ["<all_urls>"]
-    }
-  ]
+  "permissions": ["alarms", "storage"]
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,77 @@
+const FOCUS_MINUTES = 25;
+const BREAK_MINUTES = 5;
+
+async function updateBadge() {
+  const { mode, endTime } = await chrome.storage.local.get([
+    "mode",
+    "endTime",
+  ]);
+  if (!mode || !endTime) {
+    chrome.action.setBadgeText({ text: "" });
+    return;
+  }
+  const remainingMs = endTime - Date.now();
+  const remainingMin = Math.max(0, Math.ceil(remainingMs / 60000));
+  const color = mode === "focus" ? "#FF0000" : "#00AA00";
+  chrome.action.setBadgeBackgroundColor({ color });
+  chrome.action.setBadgeText({ text: String(remainingMin) });
+}
+
+async function schedulePhase(minutes, mode) {
+  const endTime = Date.now() + minutes * 60 * 1000;
+  await chrome.storage.local.set({ mode, endTime });
+  chrome.alarms.create("phase", { when: endTime });
+  chrome.alarms.create("tick", { periodInMinutes: 1, when: Date.now() + 1000 });
+  updateBadge();
+}
+
+async function startTimer() {
+  await schedulePhase(FOCUS_MINUTES, "focus");
+}
+
+async function stopTimer() {
+  await chrome.storage.local.remove(["mode", "endTime"]);
+  chrome.alarms.clear("phase");
+  chrome.alarms.clear("tick");
+  chrome.action.setBadgeText({ text: "" });
+}
+
+async function switchPhase() {
+  const { mode } = await chrome.storage.local.get("mode");
+  if (mode === "focus") {
+    await schedulePhase(BREAK_MINUTES, "break");
+  } else {
+    await schedulePhase(FOCUS_MINUTES, "focus");
+  }
+}
+
+chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+  (async () => {
+    if (msg.command === "start") {
+      await startTimer();
+      const { endTime } = await chrome.storage.local.get("endTime");
+      sendResponse({ endTime });
+    } else if (msg.command === "stop") {
+      await stopTimer();
+      sendResponse({});
+    } else if (msg.command === "getState") {
+      const { mode, endTime } = await chrome.storage.local.get([
+        "mode",
+        "endTime",
+      ]);
+      sendResponse({ running: Boolean(mode && endTime), mode, endTime });
+    }
+  })();
+  return true;
+});
+
+chrome.alarms.onAlarm.addListener((alarm) => {
+  if (alarm.name === "phase") {
+    switchPhase();
+  } else if (alarm.name === "tick") {
+    updateBadge();
+  }
+});
+
+// Initialize badge when service worker starts
+updateBadge();

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,310 +1,68 @@
 <template>
-  <div class="home">
-    <img
-      src="/assets/img/mom_img.png"
-      alt="Asian Mom Pomodoro icon"
-      class="home__icon"
-    />
-    <div class="home__timer">{{ formattedTime }}</div>
-    <div v-if="!isStarted">
-      <button class="home__start" @click="startTimer">{{ t("start") }}</button>
-    </div>
-    <div v-else class="home__controls">
-      <button v-if="isRunning" class="home__stop" @click="stopTimer">
-        {{ t("stop") }}
-      </button>
-      <button v-else class="home__start" @click="startTimer">
-        {{ t("start") }}
-      </button>
-      <button class="home__restart" @click="restartTimer">
-        {{ t("restart") }}
-      </button>
-    </div>
-    <button @click="startTimerTest">Indíts 10 mp-es időzítőt</button>
-    <button @click="openStageTabTest">Nyisd meg a stage teszt lapot</button>
-    <div class="home__debug">
-      <div>Cookies:</div>
-      <ul>
-        <li v-for="(value, key) in cookies" :key="key">
-          {{ key }}: {{ value }}
-        </li>
-      </ul>
-      <div>Storage:</div>
-      <ul>
-        <li v-for="(value, key) in storageValues" :key="key">
-          {{ key }}: {{ value }}
-        </li>
-      </ul>
-    </div>
-    Is in focus ? => {{ currentStage % 2 === 0 }}
-    <Settings @update="updateCookies" />
+  <div class="app">
+    <div class="time">{{ minutes }}:{{ seconds }}</div>
+    <button v-if="!running" @click="start">Start</button>
+    <button v-else @click="stop">Stop</button>
   </div>
 </template>
 
 <script setup>
-import Settings from "./components/Settings.vue";
-import { ref, computed, onMounted } from "vue";
-import { useI18n } from "vue-i18n";
-import {
-  getLanguage,
-  getSendMessage,
-  getPlaySound,
-  getTimerStatus,
-  setTimerStatus,
-  getTimerStarted,
-  setTimerStarted,
-  getTimerStartTime,
-  setTimerStartTime,
-  getTimerElapsed,
-  setTimerElapsed,
-} from "./settings";
+import { ref, computed, onMounted, onUnmounted } from 'vue';
 
-const { t } = useI18n();
+const running = ref(false);
+const remaining = ref(0);
+let intervalId;
 
-const cookies = ref({
-  language: getLanguage(),
-  sendMessage: getSendMessage(),
-  playSound: getPlaySound(),
-  pomodoroRunning: getTimerStatus(),
-  pomodoroStarted: getTimerStarted(),
-  pomodoroStart: getTimerStartTime(),
-  pomodoroElapsed: getTimerElapsed(),
-});
-
-const storageValues = ref({});
-
-async function loadStorageValues() {
-  if (chrome?.storage?.local) {
-    storageValues.value = await chrome.storage.local.get();
+function update(endTime) {
+  const ms = endTime - Date.now();
+  remaining.value = Math.max(0, Math.round(ms / 1000));
+  if (remaining.value <= 0) {
+    running.value = false;
+    clearInterval(intervalId);
   }
 }
 
-onMounted(() => {
-  loadStorageValues();
-  chrome?.storage?.onChanged?.addListener(loadStorageValues);
-});
-
-const stages = [
-  20 * 60, // fokus
-  5 * 60,
-  20 * 60, // fokus
-  5 * 60,
-  20 * 60, // fokus
-  5 * 60,
-  20 * 60, // fokus
-  15 * 60,
-];
-const totalDuration = stages.reduce((a, b) => a + b, 0) * 1000;
-const currentStage = ref(0);
-const timeLeft = ref(stages[0]);
-const isRunning = ref(getTimerStatus());
-const isStarted = ref(getTimerStarted());
-const startTime = ref(getTimerStartTime());
-const elapsedWhenStopped = ref(getTimerElapsed());
-
-let intervalId = null;
-
-const formattedTime = computed(() => {
-  const m = Math.floor(timeLeft.value / 60);
-  const s = timeLeft.value % 60;
-  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
-});
-
-/**
- * Tesztidőzítő indítása 10 másodpercre.
- *
- * Visszatérési érték:
- *   void: Nem ad vissza értéket.
- */
-function startTimerTest() {
-  chrome.runtime.sendMessage({ type: "START_TIMER", delayMs: 10_000 });
-}
-
-function openStageTabTest() {
-  chrome.runtime.sendMessage({
-    type: "STAGE_ACTION",
-    stage: "work",
-    openTab: true,
-  });
-}
-
-/**
- * Aktuális pomodoro állapot számítása.
- *
- * Visszatérési érték:
- *   void: Frissíti az állapotot, nem ad vissza értéket.
- */
-function calculate() {
-  if (!isStarted.value) {
-    currentStage.value = 0;
-    timeLeft.value = stages[0];
-    return;
-  }
-
-  let elapsed = isRunning.value
-    ? Date.now() - startTime.value
-    : elapsedWhenStopped.value;
-
-  if (elapsed >= totalDuration) {
-    restartTimer();
-    return;
-  }
-
-  let idx = 0;
-  let remaining = elapsed;
-  while (remaining >= stages[idx] * 1000) {
-    remaining -= stages[idx] * 1000;
-    idx++;
-  }
-  currentStage.value = idx;
-  timeLeft.value = Math.ceil((stages[idx] * 1000 - remaining) / 1000);
-}
-
-/**
- * Pomodoro időzítő elindítása vagy folytatása.
- *
- * Visszatérési érték:
- *   void: Nem ad vissza értéket.
- */
-function startTimer() {
-  if (intervalId) clearInterval(intervalId);
-
-  if (isStarted.value && !isRunning.value) {
-    startTime.value = Date.now() - elapsedWhenStopped.value;
-  } else {
-    startTime.value = Date.now();
-    elapsedWhenStopped.value = 0;
-  }
-
-  isRunning.value = true;
-  isStarted.value = true;
-  setTimerStatus(true);
-  setTimerStarted(true);
-  setTimerStartTime(startTime.value);
-  setTimerElapsed(elapsedWhenStopped.value);
-  Object.assign(cookies.value, {
-    pomodoroRunning: true,
-    pomodoroStarted: true,
-    pomodoroStart: startTime.value,
-    pomodoroElapsed: elapsedWhenStopped.value,
-  });
-
-  calculate();
-  chrome.runtime.sendMessage({
-    type: "SCHEDULE_POMODORO",
-    startTime: startTime.value,
-    stages,
-  });
-  intervalId = setInterval(calculate, 1000);
-}
-
-/**
- * Pomodoro időzítő megállítása.
- *
- * Visszatérési érték:
- *   void: Nem ad vissza értéket.
- */
-function stopTimer() {
+async function start() {
+  const res = await chrome.runtime.sendMessage({ command: 'start' });
+  running.value = true;
+  update(res.endTime);
   clearInterval(intervalId);
-  elapsedWhenStopped.value = Date.now() - startTime.value;
-  isRunning.value = false;
-  setTimerStatus(false);
-  setTimerElapsed(elapsedWhenStopped.value);
-  cookies.value.pomodoroRunning = false;
-  cookies.value.pomodoroElapsed = elapsedWhenStopped.value;
-  chrome.runtime.sendMessage({ type: "CLEAR_POMODORO_ALARMS" });
+  intervalId = setInterval(() => update(res.endTime), 1000);
 }
 
-/**
- * Pomodoro időzítő visszaállítása alaphelyzetbe.
- *
- * Visszatérési érték:
- *   void: Nem ad vissza értéket.
- */
-function restartTimer() {
+async function stop() {
+  await chrome.runtime.sendMessage({ command: 'stop' });
+  running.value = false;
   clearInterval(intervalId);
-  currentStage.value = 0;
-  timeLeft.value = stages[0];
-  isRunning.value = false;
-  isStarted.value = false;
-  startTime.value = 0;
-  elapsedWhenStopped.value = 0;
-  setTimerStatus(false);
-  setTimerStarted(false);
-  setTimerStartTime(0);
-  setTimerElapsed(0);
-  Object.assign(cookies.value, {
-    pomodoroRunning: false,
-    pomodoroStarted: false,
-    pomodoroStart: 0,
-    pomodoroElapsed: 0,
-  });
-  chrome.runtime.sendMessage({ type: "CLEAR_POMODORO_ALARMS" });
+  remaining.value = 0;
 }
 
-onMounted(() => {
-  if (isStarted.value) {
-    calculate();
-    if (isRunning.value) {
-      intervalId = setInterval(calculate, 1000);
-    }
+onMounted(async () => {
+  const state = await chrome.runtime.sendMessage({ command: 'getState' });
+  if (state.running) {
+    running.value = true;
+    update(state.endTime);
+    intervalId = setInterval(() => update(state.endTime), 1000);
   }
 });
 
-/**
- * Sütik frissítése a beállításokból kapott értékekkel.
- *
- * Paraméterek:
- *   val (object): A frissítendő kulcs–érték párok.
- *
- * Visszatérési érték:
- *   void: Nem ad vissza értéket.
- */
-function updateCookies(val) {
-  cookies.value = { ...cookies.value, ...val };
-  loadStorageValues();
-}
+onUnmounted(() => clearInterval(intervalId));
+
+const minutes = computed(() => String(Math.floor(remaining.value / 60)).padStart(2, '0'));
+const seconds = computed(() => String(remaining.value % 60).padStart(2, '0'));
 </script>
 
 <style scoped>
 .app {
-  min-width: 280px;
+  min-width: 200px;
+  text-align: center;
   padding: 16px;
-  font-family: system-ui, sans-serif;
+}
+.time {
+  font-size: 32px;
+  margin-bottom: 8px;
 }
 button {
-  margin-right: 8px;
-  padding: 8px 12px;
-  border-radius: 8px;
-  border: 1px solid #ccc;
-  cursor: pointer;
-}
-.hint {
-  margin-top: 12px;
-  font-size: 12px;
-  color: #666;
-}
-
-.home {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: flex-start;
-  min-height: 100vh;
-}
-
-.home__icon {
-  width: 128px;
-  height: 128px;
-  margin: 1rem 0;
-}
-
-.home__start {
-  margin-top: 1rem;
-}
-
-.home__timer {
-  font-size: 2rem;
-  margin-top: 1rem;
+  padding: 8px 16px;
 }
 </style>


### PR DESCRIPTION
## Summary
- replace popup UI with simple start/stop Pomodoro timer
- add service worker to manage Pomodoro phases, alarms and badge updates
- trim manifest to MV3 essentials and point background to new service worker

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8787980a08323913d1d950c84dac5