### PR TITLE
feat: polish stage popup layout and localization

### DIFF
--- a/public/stage.html
+++ b/public/stage.html
@@ -3,40 +3,105 @@
   <head>
     <meta charset="UTF-8" />
     <title>Asian Mom Pomodoro</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
     <style>
       body {
         margin: 0;
         display: flex;
-        flex-direction: column;
         justify-content: center;
         align-items: center;
         height: 100vh;
         font-family: system-ui, sans-serif;
         text-align: center;
       }
+
+      body.work {
+        background: linear-gradient(135deg, #ffe0d6, #ffcbbd);
+      }
+
+      body.break {
+        background: linear-gradient(135deg, #d6f5ff, #c1e8e2);
+      }
+
+      .card {
+        display: grid;
+        gap: 1rem;
+        place-items: center;
+        padding: 2rem;
+        border-radius: 16px;
+        background-color: rgba(255, 255, 255, 0.8);
+        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+      }
+
       img {
-        max-width: 310px;
+        max-width: 300px;
         height: auto;
       }
-      #countdown {
-        font-weight: bold;
+
+      #stageTitle {
         font-size: 2rem;
+        font-weight: bold;
       }
-      button {
-        margin-top: 20px;
-        font-size: 1.5rem;
-        padding: 0.5rem 1rem;
+
+      #countdown {
+        font-family: 'Roboto Mono', monospace;
+        font-size: 3rem;
+        font-weight: 700;
+      }
+
+      .buttons {
+        display: flex;
+        gap: 1rem;
+        margin-top: 0.5rem;
+      }
+
+      .primary-button {
+        padding: 0.5rem 1.5rem;
+        font-size: 1.25rem;
+        border: none;
         border-radius: 8px;
-        border: 1px solid #ccc;
+        color: #fff;
         cursor: pointer;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+      }
+
+      body.work .primary-button {
+        background-color: #e53935;
+      }
+
+      body.break .primary-button {
+        background-color: #43a047;
+      }
+
+      .secondary-button {
+        background: none;
+        border: none;
+        color: #666;
+        font-size: 0.9rem;
+        cursor: pointer;
+      }
+
+      .message {
+        font-size: 0.9rem;
+        color: #333;
+        max-width: 260px;
       }
     </style>
   </head>
   <body>
-    <img src="assets/img/mom_pomodoro.png" alt="Asian mom" id="momImage" />
-    <h2 id="stageTitle"></h2>
-    <div id="countdown"></div>
-    <button id="okButton">Ok</button>
+    <div class="card">
+      <img src="assets/img/mom_pomodoro.png" alt="Asian mom" id="momImage" />
+      <h2 id="stageTitle"></h2>
+      <div id="countdown"></div>
+      <div class="buttons">
+        <button id="okButton" class="primary-button">Ok</button>
+        <button id="cancelButton" class="secondary-button">Cancel</button>
+      </div>
+      <p id="momMessage" class="message"></p>
+    </div>
     <script type="module" src="stage.js"></script>
   </body>
 </html>

--- a/public/stage.js
+++ b/public/stage.js
@@ -1,12 +1,70 @@
 const params = new URLSearchParams(location.search);
 const mode = params.get("mode") === "break" ? "break" : "work";
 
+document.body.classList.add(mode);
+
 const titleEl = document.getElementById("stageTitle");
 const countdownEl = document.getElementById("countdown");
 const okBtn = document.getElementById("okButton");
+const cancelBtn = document.getElementById("cancelButton");
+const messageEl = document.getElementById("momMessage");
 
-titleEl.textContent = mode === "break" ? "Start your break" : "Work";
-countdownEl.style.color = mode === "break" ? "green" : "red";
+const translations = {
+  en: {
+    workTitle: "Work",
+    breakTitle: "Start your break",
+    okWork: "Yes mom!",
+    okBreak: "Let's go!",
+    cancel: "Cancel",
+    messages: [
+      "If you don't study now, what will you become?!",
+      "Do you think success comes by itself?",
+      "Mom's watching!",
+    ],
+  },
+  ja: {
+    workTitle: "勉強する時間よ",
+    breakTitle: "休憩を始めましょう",
+    okWork: "はい、お母さん！",
+    okBreak: "行こう！",
+    cancel: "キャンセル",
+    messages: [
+      "今勉強しないでどうするの？",
+      "みんなはもっと頑張ってるわよ！",
+      "お母さん見てるからね！",
+    ],
+  },
+  ru: {
+    workTitle: "Работай",
+    breakTitle: "Начни перерыв",
+    okWork: "Да, мам!",
+    okBreak: "Поехали!",
+    cancel: "Отмена",
+    messages: [
+      "Если сейчас не учишься, кем станешь?!",
+      "Думаешь, успех приходит сам?",
+      "Мама наблюдает!",
+    ],
+  },
+};
+
+function readCookie(name) {
+  const match = document.cookie.match(new RegExp("(?:^|; )" + name + "=([^;]*)"));
+  return match ? decodeURIComponent(match[1]) : "";
+}
+
+function getLanguage() {
+  return readCookie("language") || "en";
+}
+
+const lang = getLanguage();
+const t = translations[lang] || translations.en;
+
+titleEl.textContent = mode === "break" ? t.breakTitle : t.workTitle;
+okBtn.textContent = mode === "break" ? t.okBreak : t.okWork;
+cancelBtn.textContent = t.cancel;
+messageEl.textContent = t.messages[Math.floor(Math.random() * t.messages.length)];
+countdownEl.style.color = mode === "break" ? "#2e7d32" : "#c62828";
 
 function getPlaySound() {
   const value = readCookie("sound_enabled");
@@ -29,13 +87,6 @@ const stages = [
   15 * 60,
 ];
 const totalDuration = stages.reduce((a, b) => a + b, 0) * 1000;
-
-function readCookie(name) {
-  const match = document.cookie.match(
-    new RegExp("(?:^|; )" + name + "=([^;]*)")
-  );
-  return match ? decodeURIComponent(match[1]) : "";
-}
 
 function getTimerStarted() {
   const value = readCookie("pomodoro_started");
@@ -97,5 +148,9 @@ setInterval(updateCountdown, 1000);
 okBtn.addEventListener("click", () => {
   chrome.runtime.sendMessage({ type: "STAGE_ACTION", stage: mode });
 
+  window.close();
+});
+
+cancelBtn.addEventListener("click", () => {
   window.close();
 });


### PR DESCRIPTION
## Summary
- redesign stage popup with card layout, gradient backgrounds, and monospaced timer
- add humorous primary/secondary buttons and random mom messages
- localize popup texts based on stored language

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bacfef00808323983e474327e5b401