### PR TITLE
Stop timer when canceling stage popup

### DIFF
--- a/public/background.js
+++ b/public/background.js
@@ -249,6 +249,8 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     } else if (msg?.type === "CLEAR_POMODORO_ALARMS") {
       await clearPomodoroAlarms();
       sendResponse({ ok: true });
+    } else if (msg?.type === "CLOSE_APP_WINDOW") {
+      sendResponse({ ok: true });
     } else if (msg?.type === "STAGE_ACTION") {
       console.log("Stage action received:", msg.stage);
       if (msg.openTab) {

--- a/public/stage.js
+++ b/public/stage.js
@@ -53,6 +53,14 @@ function readCookie(name) {
   return match ? decodeURIComponent(match[1]) : "";
 }
 
+function setCookie(name, value, days = 365) {
+  const expires = new Date(Date.now() + days * 864e5).toUTCString();
+  document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/`;
+  if (chrome?.storage?.local) {
+    chrome.storage.local.set({ [name]: String(value) });
+  }
+}
+
 function getLanguage() {
   return readCookie("language") || "en";
 }
@@ -143,7 +151,7 @@ function updateCountdown() {
 }
 
 updateCountdown();
-setInterval(updateCountdown, 1000);
+const countdownInterval = setInterval(updateCountdown, 1000);
 
 okBtn.addEventListener("click", () => {
   chrome.runtime.sendMessage({ type: "STAGE_ACTION", stage: mode });
@@ -151,6 +159,15 @@ okBtn.addEventListener("click", () => {
   window.close();
 });
 
-cancelBtn.addEventListener("click", () => {
+function restartTimer() {
+  clearInterval(countdownInterval);
+  setCookie("pomodoro_running", false);
+  setCookie("pomodoro_started", false);
+  setCookie("pomodoro_start_time", 0);
+  setCookie("pomodoro_elapsed", 0);
+  chrome.runtime.sendMessage({ type: "CLEAR_POMODORO_ALARMS" });
+  chrome.runtime.sendMessage({ type: "CLOSE_APP_WINDOW" });
   window.close();
-});
+}
+
+cancelBtn.addEventListener("click", restartTimer);

--- a/src/main.js
+++ b/src/main.js
@@ -6,3 +6,9 @@ import i18n from './i18n';
 const app = createApp(App);
 app.use(i18n);
 app.mount('#app');
+
+chrome.runtime?.onMessage.addListener((msg) => {
+  if (msg?.type === 'CLOSE_APP_WINDOW') {
+    window.close();
+  }
+});


### PR DESCRIPTION
## Summary
- Close any open extension popups when canceling the stage dialog
- Listen for a `CLOSE_APP_WINDOW` message in the popup and terminate the window
- Acknowledge the message in the service worker to avoid runtime errors

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bb34dabc188323aae51c7be16281b3